### PR TITLE
新規アカウント作成後エラーになる問題を修正/レベル1->2の必要経験値やレベルアップのタイミングを修正

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,7 +2,7 @@ class Profile < ApplicationRecord
     # 自身の現在のレベル。
     def get_level
         level = 1;
-        while get_required_total_exp(level) < self[:experience] do
+        while get_required_total_exp(level) <= self[:experience] do
             level += 1
         end
         return level

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,7 +16,7 @@ class Profile < ApplicationRecord
     private
     # levelに上がるために必要な累計経験値。
     def get_required_total_exp(level)
-        total_exp = 0
+        total_exp = 1000
         for i in 1..(level-1) do
             total_exp += get_required_level_exp(i)
         end

--- a/db/migrate/20190802070025_create_profiles.rb
+++ b/db/migrate/20190802070025_create_profiles.rb
@@ -5,7 +5,7 @@ class CreateProfiles < ActiveRecord::Migration[5.2]
       t.string :goal
       t.string :daily_task
       t.integer :monthly_score
-      t.integer :experience
+      t.integer :experience, default: 0
       t.string :avatar_url
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2019_08_02_104413) do
     t.string "goal"
     t.string "daily_task"
     t.integer "monthly_score"
-    t.integer "experience"
+    t.integer "experience", default: 0
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
* 経験値に初期値がないのでコケていた